### PR TITLE
Script breaks with concatenated code

### DIFF
--- a/threex.domevents.js
+++ b/threex.domevents.js
@@ -13,7 +13,7 @@
 //
 // First you include it in your page
 //
-// ```<script src='threex.domevent.js'></script>```
+// ```<script src='threex.domevent.js'>< /script>```
 //
 // # use the object oriented api
 //


### PR DESCRIPTION
It's a well known fact not to include literal `<script>` tags in JavaScript comments for this reason.

Due to this, inline/concatenated code (where this script is dropped into the page as an inline script) will cause the JavaScript parser to end parsing at that script tag.

This is a glaring issue....